### PR TITLE
Fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add the extension to your `pom.xml` like the following:
 <project>
   <build>
     <extensions>
-      <plugin>
+      <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
         <version>1.2.3.Final</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
     </developer>
   </developers>
 
+  <prerequisites>
+    <maven>3.0</maven>
+  </prerequisites>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/src/main/java/kr/motd/maven/os/RepositorySessionInjector.java
+++ b/src/main/java/kr/motd/maven/os/RepositorySessionInjector.java
@@ -3,24 +3,32 @@ package kr.motd.maven.os;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.logging.Logger;
-import org.eclipse.aether.RepositorySystemSession;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Map;
 
 final class RepositorySessionInjector {
+
     @SuppressWarnings("unchecked")
     static void injectRepositorySession(
             Logger logger, MavenSession session, Map<String, String> dict) throws MavenExecutionException {
         // Inject repository session properties.
         try {
-            RepositorySystemSession repoSession = session.getRepositorySession();
-            Map<String, String> repoSessionProps = repoSession.getSystemProperties();
+            Map<String, String> repoSessionProps;
+            // Due to repackaging of Aether in Maven 3.1, session.getRepositorySession()
+            // will return either org.eclipse.aether.RepositorySystemSession (Maven 3.1+)
+            // or org.sonatype.aether.RepositorySystemSession (Maven 3.0.x)
+            // depending on the version of Maven that executes the project.
+            // Both interfaces have getSystemProperties() accessor method that returns Map<String, String>.
+            Object repoSession = session.getRepositorySession();
+            Class<?> cls = repoSession.getClass();
+            final Method getSystemPropertiesMethod = cls.getDeclaredMethod("getSystemProperties");
+            repoSessionProps = (Map<String, String>) getSystemPropertiesMethod.invoke(repoSession);
             try {
                 repoSessionProps.putAll(dict);
             } catch (Exception e) {
-                // Time to hack: RepositorySystemSession.getRepositorySession() returned an immutable map.
-                Class<?> cls = session.getRepositorySession().getClass();
+                // Time to hack: RepositorySystemSession.getSystemProperties() returned an immutable map.
                 Field f = cls.getDeclaredField("systemProperties");
                 f.setAccessible(true);
                 repoSessionProps = (Map<String, String>) f.get(repoSession);


### PR DESCRIPTION
It turned out that the problem was down to relocation of Aether from Sonatype to Eclipse package space, which took effect in Maven 3.1. Some additional Java reflection was needed to ensure compatibility across all Maven 3.x versions.