### PR TITLE
Enable detection of other IBM architectures.

### DIFF
--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -134,13 +134,13 @@ public abstract class Detector {
             return "ppc_64";
         }
         if (value.equals("ppc64le")) {
-            return "ppc_64_le";
+            return "ppcle_64";
         }
         if (value.equals("s390")) {
-            return "s390";
+            return "s390_32";
         }
         if (value.equals("s390x")) {
-            return "s390x";
+            return "s390_64";
         }
 
         return UNKNOWN;

--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -133,6 +133,15 @@ public abstract class Detector {
         if (value.equals("ppc64")) {
             return "ppc_64";
         }
+        if (value.equals("ppc64le")) {
+            return "ppc_64_le";
+        }
+        if (value.equals("s390")) {
+            return "s390";
+        }
+        if (value.equals("s390x")) {
+            return "s390x";
+        }
 
         return UNKNOWN;
     }


### PR DESCRIPTION
This patch adds detection of other IBM architectures like ppc64 little endian (ppc64le) and s390/s390x.