### PR TITLE
Adding detection of OS variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add the extension to your `pom.xml` like the following:
 <project>
   <build>
     <extensions>
-      <plugin>
+      <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
         <version>1.2.3.Final</version>
@@ -87,6 +87,54 @@ Use `${os.detected.classifier}` as the classifier of the produced JAR:
   </build>
 </project>
 ```
+
+### Custom classifiers for OS variants
+
+If you need to customize your deployment based on a variant of an OS, you can check the existence of `${os.detected.like.<variant>}`.
+
+The snippet below deploys an artifact with a different classifier if on an OS that is like `debian`.
+
+```xml
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target>
+                <condition property="deploy.classifier"
+                           value="${os.detected.classifier}-debian"
+                           else="${os.detected.classifier}">
+                  <isset property="os.detected.like.debian"/>
+                </condition>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <classifier>${deploy.classifier}</classifier>
+          </configuration>
+        </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+For all platforms, there will be at least one property for `os.detected.like.${os.detected.name}`. On Linux,
+additional properties will be populated from the `ID` and `ID_LIKE` entries in
+[`/etc/os-release` or `/usr/lib/os-release`](http://www.freedesktop.org/software/systemd/man/os-release.html). If unavailable
+and the file `/etc/redhat-release` exists, `rhel` and `fedora` are assumed.
 
 ### Issues with Eclipse m2e or other IDEs
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Use `${os.detected.classifier}` as the classifier of the produced JAR:
 </project>
 ```
 
-### Custom classifiers for OS variants
+### Custom classifiers for Linux variants
 
-If you need to customize your deployment based on a variant of an OS, you can check the existence of `${os.detected.like.<variant>}`.
+If you need to customize your deployment based on a variant of Linux, you can check the existence of `${os.detected.like.<variant>}`.
 
 The snippet below deploys an artifact with a different classifier if on an OS that is like `debian`.
 
@@ -131,8 +131,7 @@ The snippet below deploys an artifact with a different classifier if on an OS th
 </project>
 ```
 
-For all platforms, there will be at least one property for `os.detected.like.${os.detected.name}`. On Linux,
-additional properties will be populated from the `ID` and `ID_LIKE` entries in
+These properties are only available for Linux, and are populated from the `ID` and `ID_LIKE` entries in
 [`/etc/os-release` or `/usr/lib/os-release`](http://www.freedesktop.org/software/systemd/man/os-release.html). If unavailable
 and the file `/etc/redhat-release` exists, `rhel` and `fedora` are assumed.
 

--- a/README.md
+++ b/README.md
@@ -88,11 +88,19 @@ Use `${os.detected.classifier}` as the classifier of the produced JAR:
 </project>
 ```
 
-### Custom classifiers for Linux variants
+### Custom classifiers for specific releases of Linux
 
-If you need to customize your deployment based on a variant of Linux, you can check the existence of `${os.detected.like.<variant>}`.
+If you need to customize your deployment based on a specific release of Linux, a few other variables may
+be made available.
 
-The snippet below deploys an artifact with a different classifier if on an OS that is like `debian`.
+* `${os.detected.release}`: provides the ID for the linux release.
+* `${os.detected.release.version}`: provides version ID for this linux release. Only available if
+`${os.detected.release}` is also available.
+* `${os.detected.release.like.<variant>}`: Identifies a linux release that this release is
+"like" (for example, `ubuntu` is "like" `debian`). Only available if `${os.detected.release}` is also
+available. An entry will always be made for `os.detected.release.like.${os.detected.release}`.
+
+The snippet below deploys an artifact with a different classifier if on an OS that is "like" `debian`.
 
 ```xml
 <project>
@@ -110,7 +118,7 @@ The snippet below deploys an artifact with a different classifier if on an OS th
                 <condition property="deploy.classifier"
                            value="${os.detected.classifier}-debian"
                            else="${os.detected.classifier}">
-                  <isset property="os.detected.like.debian"/>
+                  <isset property="os.detected.release.debian"/>
                 </condition>
               </target>
             </configuration>
@@ -131,9 +139,14 @@ The snippet below deploys an artifact with a different classifier if on an OS th
 </project>
 ```
 
-These properties are only available for Linux, and are populated from the `ID` and `ID_LIKE` entries in
-[`/etc/os-release` or `/usr/lib/os-release`](http://www.freedesktop.org/software/systemd/man/os-release.html). If unavailable
-and the file `/etc/redhat-release` exists, `rhel` and `fedora` are assumed.
+For most Linux distributions, these values are populated from the `ID`, `ID_LIKE`, and `VERSION_ID`
+entries in [`/etc/os-release` or `/usr/lib/os-release`](http://www.freedesktop.org/software/systemd/man/os-release.html).
+
+If these files are unavailable, then `/etc/redhat-release` is inspected. If it contains `CentOS`,
+`Fedora`, or `Redhat Enterprise Linux` then `${os.detected.release}` will be set to `centos`,
+`fedora`, or `rhel` respectively (other variants are unsupported). "Like" entries will be created
+for `${os.detected.release}` as well as `rhel` and `fedora`. The `${os.detected.release.version}`
+variable is currently not set.
 
 ### Issues with Eclipse m2e or other IDEs
 

--- a/src/main/java/kr/motd/maven/os/DetectExtension.java
+++ b/src/main/java/kr/motd/maven/os/DetectExtension.java
@@ -86,7 +86,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         dict.put(Detector.DETECTED_ARCH, sessionProps.getProperty(Detector.DETECTED_ARCH));
         dict.put(Detector.DETECTED_CLASSIFIER, sessionProps.getProperty(Detector.DETECTED_CLASSIFIER));
         for (Map.Entry<Object, Object> entry : sessionProps.entrySet()) {
-            if (entry.getKey().toString().startsWith(Detector.DETECTED_LIKE_PREFIX)) {
+            if (entry.getKey().toString().startsWith(Detector.DETECTED_RELEASE)) {
                 dict.put(entry.getKey().toString(), entry.getValue().toString());
             }
         }
@@ -106,7 +106,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         sessionExecProps.put(Detector.DETECTED_ARCH, dict.get(Detector.DETECTED_ARCH));
         sessionExecProps.put(Detector.DETECTED_CLASSIFIER, dict.get(Detector.DETECTED_CLASSIFIER));
         for (Map.Entry<String, String> entry : dict.entrySet()) {
-            if (entry.getKey().startsWith(Detector.DETECTED_LIKE_PREFIX)) {
+            if (entry.getKey().startsWith(Detector.DETECTED_RELEASE)) {
                 sessionExecProps.put(entry.getKey(), entry.getValue());
             }
         }

--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -70,6 +70,7 @@ public abstract class Detector {
             }
         }
 
+        // Add properties for all variants that this OS is "like"
         for (String like : getOsLike(detectedName)) {
             String propKey = DETECTED_LIKE_PREFIX + like;
             setProperty(props, propKey, "true");
@@ -165,11 +166,15 @@ public abstract class Detector {
     }
 
     /**
-     * Gets a collection of OSes that the given detected OS is "like". The {@code detectedName} will
-     * always appear in the collection.
+     * Gets a collection of OSes that the given detected OS is "like".
      */
     private static Collection<String> getOsLike(String detectedName) {
         Set<String> like = new LinkedHashSet<String>();
+        if (!"linux".equals(detectedName)) {
+            // Currently only Linux is supported.
+            return like;
+        }
+
         for (String osReleaseFileName : OS_RELEASE_FILES) {
             File file = new File(osReleaseFileName);
             if (file.exists()) {
@@ -184,9 +189,6 @@ public abstract class Detector {
             like.add("rhel");
             like.add("fedora");
         }
-
-        // Always add the detected name as well.
-        like.add(detectedName);
 
         return like;
     }

--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -15,16 +15,31 @@
  */
 package kr.motd.maven.os;
 
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.Set;
 
 public abstract class Detector {
 
     public static final String DETECTED_NAME = "os.detected.name";
     public static final String DETECTED_ARCH = "os.detected.arch";
     public static final String DETECTED_CLASSIFIER = "os.detected.classifier";
+    public static final String DETECTED_LIKE_PREFIX = "os.detected.like.";
 
+    private static final String ID_PREFIX = "ID=";
+    private static final String ID_LIKE_PREFIX = "ID_LIKE=";
     private static final String UNKNOWN = "unknown";
+    private static final String[] OS_RELEASE_FILES = {"/etc/os-release", "/usr/lib/os-release"};
+    private static final String REDHAT_FILE = "/etc/redhat-release";
 
     protected void detect(Properties props) throws DetectionException {
         log("------------------------------------------------------------------------");
@@ -53,6 +68,11 @@ public abstract class Detector {
             if (UNKNOWN.equals(detectedArch)) {
                 throw new DetectionException("unknown os.arch: " + osArch);
             }
+        }
+
+        for (String like : getOsLike(detectedName)) {
+            String propKey = DETECTED_LIKE_PREFIX + like;
+            setProperty(props, propKey, "true");
         }
     }
 
@@ -142,5 +162,84 @@ public abstract class Detector {
             return "";
         }
         return value.toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
+    }
+
+    /**
+     * Gets a collection of OSes that the given detected OS is "like". The {@code detectedName} will
+     * always appear in the collection.
+     */
+    private static Collection<String> getOsLike(String detectedName) {
+        Set<String> like = new LinkedHashSet<String>();
+        for (String osReleaseFileName : OS_RELEASE_FILES) {
+            File file = new File(osReleaseFileName);
+            if (file.exists()) {
+                like.addAll(parseLinuxOsReleaseFile(file));
+                break;
+            }
+        }
+
+        // Older versions of redhat don't have /etc/os-release. In this case, just
+        // add "rhel" and "fedora" to the list.
+        if (like.isEmpty() && isRedHatVariant()) {
+            like.add("rhel");
+            like.add("fedora");
+        }
+
+        // Always add the detected name as well.
+        like.add(detectedName);
+
+        return like;
+    }
+
+    /**
+     * Indicates whether or not the OS is a variant of Redhat.
+     */
+    private static boolean isRedHatVariant() {
+        return new File(REDHAT_FILE).exists();
+    }
+
+    /**
+     * Parses a file in the format of {@code /etc/os-release} and returns a collection
+     * containing lower-case values taken from the {@code ID} and {@code ID_LIKE} entries.
+     */
+    private static Collection<String> parseLinuxOsReleaseFile(File file) {
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "utf-8"));
+
+            Set<String> likeSet = new LinkedHashSet<String>();
+            String line;
+            while((line = reader.readLine()) != null) {
+                // Parse the lines ID and ID_LIKE the same way.
+                int prefixLength = line.startsWith(ID_LIKE_PREFIX) ? ID_LIKE_PREFIX.length() :
+                    line.startsWith(ID_PREFIX) ? ID_PREFIX.length() : -1;
+                if (prefixLength < 0) {
+                    continue;
+                }
+
+                // Get the value after "=".
+                line = line.substring(prefixLength);
+
+                // Split the line on any whitespace.
+                String[] parts =  line.split("\\s+");
+                Collections.addAll(likeSet, parts);
+            }
+            return likeSet;
+        } catch (IOException ignored) {
+            // Just absorb. Don't treat failure to read /etc/os-release as an error.
+        } finally {
+            closeQuietly(reader);
+        }
+        return Collections.emptyList();
+    }
+
+    private static void closeQuietly(Closeable obj) {
+        try {
+            if (obj != null) {
+                obj.close();
+            }
+        } catch (IOException ignored) {
+            // Ignore.
+        }
     }
 }


### PR DESCRIPTION
Adding additional properties for every variant that an OS is "like". On linux, populates these properties using /etc/os-release, /usr/lib/os-release, and /etc/redhat-release.