### PR TITLE
Add support for detecting release version on CentOS 5 and CentOS 6

### DIFF
--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -303,8 +303,14 @@ public abstract class Detector {
                 line = line.toLowerCase(Locale.US);
 
                 String id;
+                String version = null;
                 if (line.contains("centos")) {
                     id = "centos";
+
+                    Matcher versionMatcher = VERSION_REGEX.matcher(line);
+                    if (versionMatcher.find()) {
+                        version = versionMatcher.group(2);
+                    }
                 } else if (line.contains("fedora")) {
                     id = "fedora";
                 } else if (line.contains("red hat enterprise linux")) {
@@ -318,7 +324,7 @@ public abstract class Detector {
                 likeSet.addAll(Arrays.asList(DEFAULT_REDHAT_VARIANTS));
                 likeSet.add(id);
 
-                return new LinuxRelease(id, null, likeSet);
+                return new LinuxRelease(id, version, likeSet);
             }
         } catch (IOException ignored) {
             // Just absorb. Don't treat failure to read /etc/os-release as an error.

--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -53,6 +53,7 @@ public abstract class Detector {
     private static final String[] DEFAULT_REDHAT_VARIANTS = {"rhel", "fedora"};
 
     private static final Pattern VERSION_REGEX = Pattern.compile("((\\d+)\\.(\\d+)).*");
+    private static final Pattern REDHAT_MAJOR_VERSION_REGEX = Pattern.compile("(\\d+)");
 
     protected void detect(Properties props, List<String> classifierWithLikes) {
         log("------------------------------------------------------------------------");
@@ -306,11 +307,6 @@ public abstract class Detector {
                 String version = null;
                 if (line.contains("centos")) {
                     id = "centos";
-
-                    Matcher versionMatcher = VERSION_REGEX.matcher(line);
-                    if (versionMatcher.find()) {
-                        version = versionMatcher.group(2);
-                    }
                 } else if (line.contains("fedora")) {
                     id = "fedora";
                 } else if (line.contains("red hat enterprise linux")) {
@@ -318,6 +314,11 @@ public abstract class Detector {
                 } else {
                     // Other variants are not currently supported.
                     return null;
+                }
+
+                Matcher versionMatcher = REDHAT_MAJOR_VERSION_REGEX.matcher(line);
+                if (versionMatcher.find()) {
+                    version = versionMatcher.group(1);
                 }
 
                 Set<String> likeSet = new LinkedHashSet<String>();


### PR DESCRIPTION
This is implemented by parsing the /etc/redhat-release file, looking for
the first instance of any two numbers separated by a '.' character. This
has held true for all versions of CentOS 5 and 6.

Examples of /etc/redhat-release from both versions:
CentOS release 5.11 (Final)
CentOS release 6.7 (Final)