### PR TITLE
Readme: eclipse plugin should go into dropins directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This will result in a `${os.detected.classifier}` of `linux-<arch>-debian` on de
 
 If you are using IntelliJ IDEA, you should not have any problem.
 
-If you are using Eclipse, you need to install an additional Eclipse plugin because [m2e](https://www.eclipse.org/m2e/) does not evaluate the extension specified in a `pom.xml`.  [Download `os-maven-plugin-1.6.0.jar`](http://repo1.maven.org/maven2/kr/motd/maven/os-maven-plugin/1.6.0/os-maven-plugin-1.6.0.jar) and put it into the `<ECLIPSE_HOME>/plugins` directory.
+If you are using Eclipse, you need to install an additional Eclipse plugin because [m2e](https://www.eclipse.org/m2e/) does not evaluate the extension specified in a `pom.xml`.  [Download `os-maven-plugin-1.6.0.jar`](http://repo1.maven.org/maven2/kr/motd/maven/os-maven-plugin/1.6.0/os-maven-plugin-1.6.0.jar) and put it into the `<ECLIPSE_HOME>/dropins` directory.
 
 (As you might have noticed, `os-maven-plugin` is a Maven extension, a Maven plugin, and an Eclipse plugin.)
 


### PR DESCRIPTION
The eclipse/plugins directory is reserved for p2 (aka managed installation), so prefer the /dropins
directory instead. It exists precisely for user-supplied extensions.
