### PR TITLE
Add detection of z/OS operating system

### DIFF
--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -168,6 +168,9 @@ public abstract class Detector {
         if (value.startsWith("windows")) {
             return "windows";
         }
+        if (value.startsWith("zos")) {
+            return "zos";
+        }
 
         return UNKNOWN;
     }


### PR DESCRIPTION
Fixes #39.

This simple pull request just adds detection of the z/OS operating system.

Note that detection and normalization of the architecture is already covered (`s390x`).