### PR TITLE
Fixes #36 new property "os.detected.bitness".

### DIFF
--- a/src/main/java/kr/motd/maven/os/DetectExtension.java
+++ b/src/main/java/kr/motd/maven/os/DetectExtension.java
@@ -47,6 +47,8 @@ import org.codehaus.plexus.util.InterpolationFilterReader;
  * <ul>
  * <li>{@code os.detected.name} - normalized {@code os.name} (e.g. {@code linux}, {@code osx})</li>
  * <li>{@code os.detected.arch} - normalized {@code os.arch} (e.g. {@code x86_64}, {@code x86_32})</li>
+ * <li>{@code os.detected.bitness} - bitness from wither {@code sun.arch.data.model} or {@code com.ibm.vm.bitmode} or {@code os.arch}
+ *     (e.g. {@code 64}, {@code 32})</li>
  * <li>{@code os.detected.version} - {@code os.detected.version.major}.{@code os.detected.version.minor}</li>
  * <li>{@code os.detected.version.major} - major part of {@code os.version} (integer value)</li>
  * <li>{@code os.detected.version.minor} - minor part of {@code os.version} (integer value)</li>
@@ -104,6 +106,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         final Map<String, String> dict = new LinkedHashMap<String, String>();
         dict.put(Detector.DETECTED_NAME, sessionProps.getProperty(Detector.DETECTED_NAME));
         dict.put(Detector.DETECTED_ARCH, sessionProps.getProperty(Detector.DETECTED_ARCH));
+        dict.put(Detector.DETECTED_BITNESS, sessionProps.getProperty(Detector.DETECTED_BITNESS));
         dict.put(Detector.DETECTED_CLASSIFIER, sessionProps.getProperty(Detector.DETECTED_CLASSIFIER));
         for (Map.Entry<Object, Object> entry : sessionProps.entrySet()) {
             if (entry.getKey().toString().startsWith(Detector.DETECTED_RELEASE)) {

--- a/src/main/java/kr/motd/maven/os/DetectMojo.java
+++ b/src/main/java/kr/motd/maven/os/DetectMojo.java
@@ -35,6 +35,8 @@ import org.apache.maven.project.MavenProject;
  * <ul>
  * <li>{@code os.detected.name} - normalized {@code os.name} (e.g. {@code linux}, {@code osx})</li>
  * <li>{@code os.detected.arch} - normalized {@code os.arch} (e.g. {@code x86_64}, {@code x86_32})</li>
+ * <li>{@code os.detected.bitness} - bitness from wither {@code sun.arch.data.model} or {@code com.ibm.vm.bitmode} or {@code os.arch}
+ *     (e.g. {@code 64}, {@code 32})</li>
  * <li>{@code os.detected.classifier} - a shortcut for {@code 'os.detectedName'.'os.detectedArch'}
  *     (e.g. {@code linux-x86_64}). If the property {@code ${os.detection.classifierWithLikes}} is set,
  *     the first value for which a corresponding {@code os.detected.release.like.{variant}} property


### PR DESCRIPTION
Caveats:
  - might result in '31' for zOS legacy systems.
  - will report '32' for a 32-bit JVM running on a 64bit system.