### PR TITLE
Changing the 'os.detected.arch' property for s390 and s390x

### DIFF
--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -226,7 +226,7 @@ public abstract class Detector {
             return "ppcle_64";
         }
         if ("s390".equals(value)) {
-            return "s390_32";
+            return "s390";
         }
         if ("s390x".equals(value)) {
             return "s390x";

--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -229,7 +229,7 @@ public abstract class Detector {
             return "s390_32";
         }
         if ("s390x".equals(value)) {
-            return "s390_64";
+            return "s390x";
         }
 
         return UNKNOWN;


### PR DESCRIPTION
os.detected.arch on s390 is returned as `s390_32` and for s390x it is returned as `s390_64` which needs to be corrected. This PR is for fixing the same.