### PR TITLE
Support for E2K (Elbrus 2000) architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 * `s390_32` - if the value is `s390`
 * `s390_64` if the value is `s390x`
 * `riscv` if the value is `riscv`
+* `e2k` if the value is `e2k`
 
 Note: The bitness part of this property relies on the bitness of the JVM binary, e.g. You'll get the property that ends with `_32` if you run a 32-bit JVM on a 64-bit OS.
 

--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -248,6 +248,9 @@ public abstract class Detector {
         if ("riscv".equals(value)) {
             return "riscv";
         }
+        if ("e2k".equals(value)) {
+            return "e2k";
+        }
         return UNKNOWN;
     }
 


### PR DESCRIPTION
Hi there. I suggest adding support for e2k architecture.

Currently when building some projects like netty, i'm getting this:

```
admin@srv-e2k-01:~/netty$ mvn compile
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: linux
[INFO] os.detected.arch: unknown
[INFO] os.detected.bitness: 64
[INFO] os.detected.version: 5.4
[INFO] os.detected.version.major: 5
[INFO] os.detected.version.minor: 4
[ERROR] unknown os.arch: e2k -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MavenExecutionException
```