### PR TITLE
Make it possible to use the detected properties before reading pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+
+    <!-- Using the same java.home for IT -->
+    <invoker.javaHome>${java.home}</invoker.javaHome>
   </properties>
 
   <dependencies>
@@ -189,6 +192,36 @@
             </manifestEntries>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.2.2</version>
+        <configuration>
+          <debug>true</debug>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+          <pomIncludes>
+            <pomInclude>*/pom.xml</pomInclude>
+          </pomIncludes>
+          <postBuildHookScript>verify</postBuildHookScript>
+<!--          <settingsFile>src/it/settings.xml</settingsFile>-->
+          <streamLogs>true</streamLogs>
+          <goals>
+            <goal>clean</goal>
+            <goal>package</goal>
+          </goals>
+        </configuration>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>install</goal>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/it/test-activate-profile/.mvn/extensions.xml
+++ b/src/it/test-activate-profile/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/src/it/test-activate-profile/pom.xml
+++ b/src/it/test-activate-profile/pom.xml
@@ -66,5 +66,18 @@
                 <active.profile>detected-ubuntu</active.profile>
             </properties>
         </profile>
+
+        <profile>
+            <id>detected-osx</id>
+            <activation>
+                <property>
+                    <name>os.detected.name</name>
+                    <value>osx</value>
+                </property>
+            </activation>
+            <properties>
+                <active.profile>detected-osx</active.profile>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/src/it/test-activate-profile/pom.xml
+++ b/src/it/test-activate-profile/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>kr.motd.maven.it</groupId>
+    <artifactId>test-01</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>
+        An integration test that checks whether the profile can be activated by detected properties. If the
+        project.properties file contains the "active.profile" property and it has the expected value, the test is
+        considered successful.
+    </description>
+
+    <prerequisites>
+        <!-- (since Maven 3.3.1) configure your extension in .mvn/extensions.xml -->
+        <!-- https://maven.apache.org/examples/maven-3-lifecycle-extensions.html -->
+        <maven>3.3.1</maven>
+    </prerequisites>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>write-project-properties</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>write-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>${project.build.directory}/project.properties</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>detected-windows</id>
+            <activation>
+                <property>
+                    <name>os.detected.name</name>
+                    <value>windows</value>
+                </property>
+            </activation>
+            <properties>
+                <active.profile>detected-windows</active.profile>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/src/it/test-activate-profile/pom.xml
+++ b/src/it/test-activate-profile/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>kr.motd.maven.it</groupId>
-    <artifactId>test-01</artifactId>
+    <artifactId>test-activate-profile</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <description>

--- a/src/it/test-activate-profile/pom.xml
+++ b/src/it/test-activate-profile/pom.xml
@@ -53,5 +53,18 @@
                 <active.profile>detected-windows</active.profile>
             </properties>
         </profile>
+
+        <profile>
+            <id>detected-ubuntu</id>
+            <activation>
+                <property>
+                    <name>os.detected.release</name>
+                    <value>ubuntu</value>
+                </property>
+            </activation>
+            <properties>
+                <active.profile>detected-ubuntu</active.profile>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/src/it/test-activate-profile/verify.groovy
+++ b/src/it/test-activate-profile/verify.groovy
@@ -1,3 +1,4 @@
+import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.SystemUtils
 
 def projectPropertiesFile = new File(basedir, "target/project.properties")
@@ -12,4 +13,10 @@ projectPropertiesFile.withInputStream {
 
 if (SystemUtils.IS_OS_WINDOWS) {
     assert projectProperties."active.profile" == 'detected-windows'
+} else if (SystemUtils.IS_OS_LINUX) {
+    String osReleaseContent = FileUtils.readFileToString(new File("/etc/os-release"))
+
+    if (osReleaseContent.contains("id=ubuntu")) {
+        assert projectProperties."active.profile" == 'detected-ubuntu'
+    }
 }

--- a/src/it/test-activate-profile/verify.groovy
+++ b/src/it/test-activate-profile/verify.groovy
@@ -1,0 +1,15 @@
+import org.apache.commons.lang3.SystemUtils
+
+def projectPropertiesFile = new File(basedir, "target/project.properties")
+
+assert projectPropertiesFile.exists() : "project.properties not found"
+assert projectPropertiesFile.canRead() : "project.properties cannot be read"
+
+Properties projectProperties = new Properties()
+projectPropertiesFile.withInputStream {
+    projectProperties.load(it)
+}
+
+if (SystemUtils.IS_OS_WINDOWS) {
+    assert projectProperties."active.profile" == 'detected-windows'
+}

--- a/src/it/test-activate-profile/verify.groovy
+++ b/src/it/test-activate-profile/verify.groovy
@@ -16,7 +16,7 @@ if (SystemUtils.IS_OS_WINDOWS) {
 } else if (SystemUtils.IS_OS_LINUX) {
     String osReleaseContent = FileUtils.readFileToString(new File("/etc/os-release"))
 
-    if (osReleaseContent.contains("id=ubuntu")) {
+    if (osReleaseContent.contains("ID=ubuntu")) {
         assert projectProperties."active.profile" == 'detected-ubuntu'
     }
 }

--- a/src/it/test-activate-profile/verify.groovy
+++ b/src/it/test-activate-profile/verify.groovy
@@ -19,4 +19,6 @@ if (SystemUtils.IS_OS_WINDOWS) {
     if (osReleaseContent.contains("ID=ubuntu")) {
         assert projectProperties."active.profile" == 'detected-ubuntu'
     }
+} else if (SystemUtils.IS_OS_MAC) {
+    assert projectProperties."active.profile" == 'detected-osx'
 }

--- a/src/main/java/kr/motd/maven/os/DetectExtension.java
+++ b/src/main/java/kr/motd/maven/os/DetectExtension.java
@@ -15,17 +15,6 @@
  */
 package kr.motd.maven.os;
 
-import org.apache.maven.AbstractMavenLifecycleParticipant;
-import org.apache.maven.MavenExecutionException;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.*;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.util.InterpolationFilterReader;
-
-import javax.annotation.Nullable;
-import javax.inject.Inject;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -33,6 +22,24 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Exclusion;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.ModelBase;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.InterpolationFilterReader;
 
 /**
  * Detects the current operating system and architecture, normalizes them, and sets them to various project
@@ -155,7 +162,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         }
 
         // Work around the 'NoClassDefFoundError' or 'ClassNotFoundException' related with Aether in IntelliJ IDEA.
-        for (StackTraceElement e : new Exception().getStackTrace()) {
+        for (StackTraceElement e: new Exception().getStackTrace()) {
             if (String.valueOf(e.getClassName()).startsWith("org.jetbrains.idea.maven")) {
                 return;
             }
@@ -173,7 +180,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
 
         interpolate(dict, p.getParent());
         interpolate(dict, p.getModel());
-        for (ModelBase model : p.getActiveProfiles()) {
+        for (ModelBase model: p.getActiveProfiles()) {
             interpolate(dict, model);
         }
     }
@@ -193,11 +200,11 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         if (model instanceof Model) {
             final Build build = ((Model) model).getBuild();
             if (build != null) {
-                for (Plugin bp : build.getPlugins()) {
+                for (Plugin bp: build.getPlugins()) {
                     interpolate(dict, bp.getDependencies());
                 }
                 if (build.getPluginManagement() != null) {
-                    for (Plugin bp : build.getPluginManagement().getPlugins()) {
+                    for (Plugin bp: build.getPluginManagement().getPlugins()) {
                         interpolate(dict, bp.getDependencies());
                     }
                 }
@@ -210,13 +217,13 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
             return;
         }
 
-        for (Dependency d : dependencies) {
+        for (Dependency d: dependencies) {
             d.setGroupId(interpolate(dict, d.getGroupId()));
             d.setArtifactId(interpolate(dict, d.getArtifactId()));
             d.setVersion(interpolate(dict, d.getVersion()));
             d.setClassifier(interpolate(dict, d.getClassifier()));
             d.setSystemPath(interpolate(dict, d.getSystemPath()));
-            for (Exclusion e : d.getExclusions()) {
+            for (Exclusion e: d.getExclusions()) {
                 e.setGroupId(interpolate(dict, e.getGroupId()));
                 e.setArtifactId(interpolate(dict, e.getArtifactId()));
             }
@@ -229,16 +236,17 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
             return null;
         }
 
-        for (; ; ) {
+        for (;;) {
             if (!value.contains("${")) {
                 // Nothing to interpolate.
                 break;
             }
 
-            @SuppressWarnings({"unchecked", "rawtypes"}) final InterpolationFilterReader reader = new InterpolationFilterReader(
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            final InterpolationFilterReader reader = new InterpolationFilterReader(
                     new StringReader(value), (Map<String, Object>) (Map) dict);
             final StringWriter writer = new StringWriter(value.length());
-            for (; ; ) {
+            for (;;) {
                 final int ch;
                 try {
                     ch = reader.read();

--- a/src/main/java/kr/motd/maven/os/DetectExtension.java
+++ b/src/main/java/kr/motd/maven/os/DetectExtension.java
@@ -15,6 +15,17 @@
  */
 package kr.motd.maven.os;
 
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.*;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.InterpolationFilterReader;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -22,24 +33,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-
-import org.apache.maven.AbstractMavenLifecycleParticipant;
-import org.apache.maven.MavenExecutionException;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Build;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.model.Exclusion;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.ModelBase;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.util.InterpolationFilterReader;
 
 /**
  * Detects the current operating system and architecture, normalizes them, and sets them to various project
@@ -90,8 +83,16 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         };
     }
 
+    public void afterSessionStart(MavenSession session) throws MavenExecutionException {
+        injectProperties(session);
+    }
+
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
+        injectProperties(session);
+    }
+
+    private void injectProperties(MavenSession session) throws MavenExecutionException {
         // Detect the OS and CPU architecture.
         final Properties sessionProps = new Properties();
         sessionProps.putAll(session.getSystemProperties());
@@ -118,8 +119,10 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         injectSession(session, dict);
 
         /// Perform the interpolation for the properties of all dependencies.
-        for (MavenProject p: session.getProjects()) {
-            interpolate(dict, p);
+        if (session.getProjects() != null) {
+            for (MavenProject p : session.getProjects()) {
+                interpolate(dict, p);
+            }
         }
     }
 
@@ -131,9 +134,13 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         // Check to see if the project defined the
         final Properties props = new Properties();
         props.putAll(session.getUserProperties());
-        props.putAll(session.getCurrentProject().getProperties());
+
+        if (session.getCurrentProject() != null) {
+            props.putAll(session.getCurrentProject().getProperties());
+        }
+
         return DetectMojo.getClassifierWithLikes(
-            props.getProperty(DetectMojo.CLASSIFIER_WITH_LIKES_PROPERTY));
+                props.getProperty(DetectMojo.CLASSIFIER_WITH_LIKES_PROPERTY));
     }
 
     private void injectSession(MavenSession session, Map<String, String> dict) {
@@ -148,7 +155,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         }
 
         // Work around the 'NoClassDefFoundError' or 'ClassNotFoundException' related with Aether in IntelliJ IDEA.
-        for (StackTraceElement e: new Exception().getStackTrace()) {
+        for (StackTraceElement e : new Exception().getStackTrace()) {
             if (String.valueOf(e.getClassName()).startsWith("org.jetbrains.idea.maven")) {
                 return;
             }
@@ -166,7 +173,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
 
         interpolate(dict, p.getParent());
         interpolate(dict, p.getModel());
-        for (ModelBase model: p.getActiveProfiles()) {
+        for (ModelBase model : p.getActiveProfiles()) {
             interpolate(dict, model);
         }
     }
@@ -186,11 +193,11 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         if (model instanceof Model) {
             final Build build = ((Model) model).getBuild();
             if (build != null) {
-                for (Plugin bp: build.getPlugins()) {
+                for (Plugin bp : build.getPlugins()) {
                     interpolate(dict, bp.getDependencies());
                 }
                 if (build.getPluginManagement() != null) {
-                    for (Plugin bp: build.getPluginManagement().getPlugins()) {
+                    for (Plugin bp : build.getPluginManagement().getPlugins()) {
                         interpolate(dict, bp.getDependencies());
                     }
                 }
@@ -203,13 +210,13 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
             return;
         }
 
-        for (Dependency d: dependencies) {
+        for (Dependency d : dependencies) {
             d.setGroupId(interpolate(dict, d.getGroupId()));
             d.setArtifactId(interpolate(dict, d.getArtifactId()));
             d.setVersion(interpolate(dict, d.getVersion()));
             d.setClassifier(interpolate(dict, d.getClassifier()));
             d.setSystemPath(interpolate(dict, d.getSystemPath()));
-            for (Exclusion e: d.getExclusions()) {
+            for (Exclusion e : d.getExclusions()) {
                 e.setGroupId(interpolate(dict, e.getGroupId()));
                 e.setArtifactId(interpolate(dict, e.getArtifactId()));
             }
@@ -222,17 +229,16 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
             return null;
         }
 
-        for (;;) {
+        for (; ; ) {
             if (!value.contains("${")) {
                 // Nothing to interpolate.
                 break;
             }
 
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            final InterpolationFilterReader reader = new InterpolationFilterReader(
+            @SuppressWarnings({"unchecked", "rawtypes"}) final InterpolationFilterReader reader = new InterpolationFilterReader(
                     new StringReader(value), (Map<String, Object>) (Map) dict);
             final StringWriter writer = new StringWriter(value.length());
-            for (;;) {
+            for (; ; ) {
                 final int ch;
                 try {
                     ch = reader.read();

--- a/src/main/java/kr/motd/maven/os/DetectExtension.java
+++ b/src/main/java/kr/motd/maven/os/DetectExtension.java
@@ -148,7 +148,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         }
 
         return DetectMojo.getClassifierWithLikes(
-                props.getProperty(DetectMojo.CLASSIFIER_WITH_LIKES_PROPERTY));
+            props.getProperty(DetectMojo.CLASSIFIER_WITH_LIKES_PROPERTY));
     }
 
     private void injectSession(MavenSession session, Map<String, String> dict) {

--- a/src/main/java/kr/motd/maven/os/DetectExtension.java
+++ b/src/main/java/kr/motd/maven/os/DetectExtension.java
@@ -90,6 +90,7 @@ public class DetectExtension extends AbstractMavenLifecycleParticipant {
         };
     }
 
+    @Override
     public void afterSessionStart(MavenSession session) throws MavenExecutionException {
         injectProperties(session);
     }


### PR DESCRIPTION
Hi, 
Currently, it is not possible to use the detected properties to activate profiles.

PR implements afterSessionStart in addition to afterProjectsRead. This makes it possible to use the detected properties to activate profiles.

```
...
<profile>
  <id>Ubuntu</id>
  <activation>
    <property>
      <name>os.detected.release</name>
      <value>ubuntu</value>
    </property>
  </activation>
...
  <!-- Now you can do Ubuntu-specific work -->
...
</profile>
```

It would be great if this functionality was available in the extension.

Also added integration test that checks whether the profile can be activated by detected properties