### PR TITLE
Add support for riscv64 and riscv32

### DIFF
--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -245,7 +245,7 @@ public abstract class Detector {
         if ("s390x".equals(value)) {
             return "s390_64";
         }
-        if ("riscv".equals(value)) {
+        if (value.matches("^riscv(32|64)?$")) {
             return "riscv";
         }
         if ("e2k".equals(value)) {


### PR DESCRIPTION
The OpenJDK sets `os.arch` to `riscv64` or `riscv32`. This trips the architecture detection as it assumes the `os.arch=riscv` on RISC-V. Adds support for `riscv32` and `riscv64` to return `riscv` regardless. The bitness will be detected in `guessBitnessFromArchitecture`