### PR TITLE
Detect more `osx` variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 * `hpux` - if the value starts with `hpux`
 * `os400` - if the value starts with `os400` and its following character is *not* a digit (e.g. `os4000`)
 * `linux` - if the value starts with `linux`
-* `osx` - if the value starts with `macosx` or `osx`
+* `osx` - if the value starts with `mac` or `osx`
 * `freebsd` - if the value starts with `freebsd`
 * `openbsd` - if the value starts with `openbsd`
 * `netbsd` - if the value starts with `netbsd`

--- a/src/main/java/kr/motd/maven/os/Detector.java
+++ b/src/main/java/kr/motd/maven/os/Detector.java
@@ -164,7 +164,7 @@ public abstract class Detector {
         if (value.startsWith("linux")) {
             return "linux";
         }
-        if (value.startsWith("macosx") || value.startsWith("osx")) {
+        if (value.startsWith("mac") || value.startsWith("osx")) {
             return "osx";
         }
         if (value.startsWith("freebsd")) {


### PR DESCRIPTION
Motivation:

It looks like some JDK implementations do neither return `macosx` or `osx` for `System.getProperty("os.arch")`.

Modifications:

- Return `osx` when `os.arch` starts with `mac` instead of `macosx`, so that the plugin detects both `mac` and `macosx`.

Result:

- Fixes #58