### PR TITLE
fix: NoSuchMethodException #76

### DIFF
--- a/src/main/java/kr/motd/maven/os/RepositorySessionInjector.java
+++ b/src/main/java/kr/motd/maven/os/RepositorySessionInjector.java
@@ -21,7 +21,7 @@ final class RepositorySessionInjector {
             // Both interfaces have getSystemProperties() accessor method that returns Map<String, String>.
             final Object repoSession = session.getRepositorySession();
             final Class<?> cls = repoSession.getClass();
-            final Method getSystemPropertiesMethod = cls.getDeclaredMethod("getSystemProperties");
+            final Method getSystemPropertiesMethod = cls.getMethod("getSystemProperties");
             repoSessionProps = (Map<String, String>) getSystemPropertiesMethod.invoke(repoSession);
             try {
                 for (Map.Entry<String, String> e : dict.entrySet()) {


### PR DESCRIPTION
When executed by Eclipse M2E Integration, a FilterRepositorySystemSession object which extends RepositorySystemSession is returned that does not directly declare the `getSystemPropeties` method. `Class#getDeclaredMethod()` however does not take inherited methods into account and throws a NoSuchMethodException. This is fixed by using `Class#getMethod()` instead.